### PR TITLE
add missing async to for loop in `kanao.restore_reaction_roles()`

### DIFF
--- a/kanao.py
+++ b/kanao.py
@@ -295,7 +295,7 @@ async def restore_reaction_roles():
             return
 
         _guild = bot.get_guild(int(SERVER_ID))
-        for reaction in _msg.reactions:
+        async for reaction in _msg.reactions:
             try:
                 _role = discord.utils.get(_guild.roles, name=REACTION_ROLES_MAP[reaction.emoji])
             except KeyError:


### PR DESCRIPTION
Add a missing `async`-mention to a for loop.

This will cause Python to run the loop-body in parallel for every element in the list (for every reaction in this case) and therefore speed up execution speed.

Credit goes to @ericfinger, since I just found this in L307 that he wrote in this exact same file. :upside_down_face: Just seems to be missing here.