### PR TITLE
Split Modules: Spread functionality across multiple files.

### DIFF
--- a/kanao.py
+++ b/kanao.py
@@ -34,6 +34,7 @@ load functionality that is defined in other modules
 """
 bot.load_extension("roles")
 bot.load_extension("message_events")
+bot.load_extension("purge")
 
 
 @bot.command(aliases=["h", "help"])
@@ -44,28 +45,6 @@ async def custom_help(ctx):
                     'k!pingRole @role to ping that role (make sure to put a spacebar after the role, so it looks like a ping!)\n' + 
                     '```', reference=ctx.message)
 
-"""
-
-allows purging of up to 100 messages. only mods and admins.
-factors in the commanding messages automatically 
-
-"""
-
-@bot.command()
-@commands.has_any_role("Moderator", "Admin")
-async def purge(ctx, arg):
-    _to_delete = int(arg) + 1
-    _delete_list = []
-    async for message in ctx.history(limit=_to_delete):
-        _delete_list.append(message)
-    logger.info(f"Purging {_to_delete} messages for user '{ctx.author.name}' in channel '{ctx.channel.name}'")
-    await ctx.channel.delete_messages(_delete_list)
-
-@purge.error
-async def purge_error(ctx, error):
-    logger.error(f"Purge Error for user '{ctx.author.name}' in channel '{ctx.channel.name}': {error}")
-    if isinstance(error, commands.MissingAnyRole):
-        await ctx.send("No perms? 🤨", delete_after=10, reference=ctx.message)
 
 """
 
@@ -73,8 +52,6 @@ method to make the user use the bot to ping roles.
 this ensures we can log pings to roles, and that people only ping roles they have themselves.
 
 """
-
-
 @bot.command(aliases=['pr'])
 async def pingRole(ctx, arg):
     _raw_role_ID = ctx.message.raw_role_mentions       # this returns a LIST, not an INT

--- a/kanao.py
+++ b/kanao.py
@@ -10,7 +10,6 @@ import os
 import logging
 from dotenv import load_dotenv
 from discord.ext import commands
-from discord.utils import get
 
 logger = logging.getLogger(__name__)
 
@@ -35,6 +34,7 @@ load functionality that is defined in other modules
 bot.load_extension("roles")
 bot.load_extension("message_events")
 bot.load_extension("purge")
+bot.load_extension("misc")
 
 
 @bot.command(aliases=["h", "help"])
@@ -44,66 +44,6 @@ async def custom_help(ctx):
                     'k!purge n to delete the last n+1 messages (mod+ only, <= 100 max) \n' + 
                     'k!pingRole @role to ping that role (make sure to put a spacebar after the role, so it looks like a ping!)\n' + 
                     '```', reference=ctx.message)
-
-
-"""
-
-method to make the user use the bot to ping roles.
-this ensures we can log pings to roles, and that people only ping roles they have themselves.
-
-"""
-@bot.command(aliases=['pr'])
-async def pingRole(ctx, arg):
-    _raw_role_ID = ctx.message.raw_role_mentions       # this returns a LIST, not an INT
-    if not _raw_role_ID:                               # will be empty if @everyone/@here or if no mention (duh)
-        logger.warning(f"User '{ctx.author.name}' tried to ping with empty _raw_role_ID (@everone/@here/no mention) in channel '{ctx.channel.name}'")
-        await ctx.send("Make sure to put @role and a spacebar behind, so it looks like a ping. \nI wont ping @ everyone or @ here.", reference=ctx.message)
-        return
-
-    _roleName = get(ctx.guild.roles, id=_raw_role_ID[0])
-    
-    if _roleName in ctx.author.roles:
-        logger.info(f"Pinging role '{_roleName}' for user '{ctx.author.name}' in channel '{ctx.channel.name}'")
-        await ctx.send('<@&' + str(_raw_role_ID[0]) + '>', reference=ctx.message)
-    else :
-        logger.warning(f"User '{ctx.author.name}' tried to ping role '{_roleName}' in channel '{ctx.channel.name}', but they don't have that role")
-        await ctx.send('You need to have the role yourself to have me ping it!')
-
-
-"""
-
-gives the mentioned users pfp
-
-"""
-
-@bot.command(aliases=['av'])
-async def avatar(ctx):
-    for _user in ctx.message.mentions:
-        logger.info(f"Showing avatar from user '{_user}' for user '{ctx.author.name}' in channel '{ctx.channel.name}'")
-        await ctx.send(_user.avatar_url)
-
-@bot.command()
-async def cat(ctx, arg='UwU'):
-    # Sauce: https://http.cat
-    _valid_http_status_codes = [
-     "100", "101", "102", "200", "201", "202", "203", "204", "206",
-     "207", "300", "301", "302", "303", "304", "305", "307", "308",
-     "400", "401", "402", "403", "404", "405", "406", "407", "408",
-     "409", "410", "411", "412", "413", "414", "415", "416", "417",
-     "418", "420", "421", "422", "424", "425", "426", "429", "431",
-     "444", "450", "451", "497", "498", "499", "500", "501", "502",
-     "503", "504", "506", "507", "508", "509", "510", "511", "521",
-     "523", "525", "599"
-    ]
-
-    if arg in _valid_http_status_codes:
-        await ctx.send(f'https://http.cat/{arg}')
-        logger.info(f"Sent http-cat with statuscode '{arg}' for user '{ctx.author.name}' in channel '{ctx.channel.name}'")
-    else:
-        logger.warning(f"Invalid status code ({arg}) from user '{ctx.author.name}' in channel '{ctx.channel.name}'")
-        await ctx.send('You must supply a valid numeric http status code!')
-        await ctx.send('https://http.cat/400')
-
 
 def main():
     logging.basicConfig(format='%(asctime)s %(levelname)s - [%(funcName)s() @ %(module)s.py:%(lineno)d] %(message)s', datefmt='%d-%m-%y %H:%M:%S', level=logging.INFO)

--- a/kanao.py
+++ b/kanao.py
@@ -12,8 +12,6 @@ from dotenv import load_dotenv
 from discord.ext import commands
 from discord.utils import get
 
-from reaction_roles import *
-
 logger = logging.getLogger(__name__)
 
 load_dotenv()
@@ -32,62 +30,9 @@ bot = commands.Bot(command_prefix='k!', intents=intents, help_command=None)
 
 """
 
-Check for missed reactions while offline
-
+load functionality that is defined in other modules
 """
-
-@bot.event
-async def on_ready():
-    logger.info(f'{bot.user} has connected to Discord')
-    if SERVER_ID is not None:
-        logger.info("Checking if we missed any reaction roles while offline")
-        await restore_reaction_roles()
-    else:
-        logger.warning("No SERVER_ID set, skipping reaction role restoration")
-    logger.info(f'{bot.user} has finished initialising')
-    await bot.change_presence(activity=discord.Game(name="k!help"))
-
-"""
-
-Reaction roles add
-
-"""
-
-@bot.event
-async def on_raw_reaction_add(payload):
-    _role = await get_role(payload)
-    if _role is not None:
-        try:
-            await payload.member.add_roles(_role)
-            logger.info(f"Added role '{_role.name}' to user '{payload.member.name}'")
-        except discord.HTTPException:
-            logger.error("HTTPException")
-            payload.channel.send("It appears the discord API is not available.\nPlease contact an admin if the problem persists.", delete_after=30)
-            pass
-
-"""
-
-Reaction roles remove
-
-"""
-@bot.event
-async def on_raw_reaction_remove(payload):
-    _role = await get_role(payload)
-
-    if _role is not None:
-        try:
-            _guild = bot.get_guild(payload.guild_id)
-            _member = _guild.get_member(payload.user_id)
-            if _member is None:
-                logger.error(f"Could not find user '{_member.name}'")
-                return
-
-            await _member.remove_roles(_role)
-            logger.info(f"Removed role '{_role.name}' from user '{_member.name}'")
-        except discord.HTTPException:
-            logger.error("HTTPException")
-            payload.channel.send("It appears the discord API is not available.\nPlease contact an admin if the problem persists.", delete_after=30)
-            pass
+bot.load_extension("roles")
 
 """
 
@@ -248,86 +193,6 @@ async def cat(ctx, arg='UwU'):
         await ctx.send('You must supply a valid numeric http status code!')
         await ctx.send('https://http.cat/400')
 
-
-"""
-
-Retrieves a role for a given reaction by looking up the emoji in the REACTION_ROLES_MAP list.
-Also clears reaction-emojis that are not in the list from the message
-
-"""
-async def get_role(payload):
-    if payload.message_id in REACTION_ROLE_MSG_IDS.values():
-        _guild = bot.get_guild(payload.guild_id)
-        if _guild is None:
-            logger.error("No guild/server??")
-            return
-        try:
-            return discord.utils.get(_guild.roles, name=REACTION_ROLES_MAP[payload.emoji.name])
-        except KeyError:
-            print("Reaction roles: Role for Emoji '" + payload.emoji.name + "' not found, removing reaction.")
-            _channel = bot.get_channel(payload.channel_id)
-            logger.warning(f"User '{payload.member.name}' reacted with '{payload.emoji.name}' in channel '{_channel.name}', but no role was found for that emoji. Removing reaction")
-            _msg = await _channel.fetch_message(payload.message_id)
-            for _reaction in _msg.reactions:
-                if str(_reaction.emoji) == str(payload.emoji):
-                    await _reaction.clear()
-                print("Reaction Roles: Cleared reaction")
-                return
- 
-
-"""
-
-Checks if all users who reacted to the selfroles-msg have the corresponding role & gives it to them if they don't.
-Also clears all reactions that are not corresponding to a role.
-
-"""
-async def restore_reaction_roles():
-    for channel_id in REACTION_ROLE_MSG_IDS.keys():
-        _channel = bot.get_channel(channel_id)
-        if _channel is None:
-            logger.error(f"Could not restore reaction roles: channel_id '{channel_id}' not found. Quitting")
-            return
-
-        try:
-            _msg = await _channel.fetch_message(REACTION_ROLE_MSG_IDS[channel_id])
-        except Exception as e:
-            logger.error(f"Could not fetch channel: {e}")
-            return
-
-        _guild = bot.get_guild(int(SERVER_ID))
-        for reaction in _msg.reactions:
-            try:
-                _role = discord.utils.get(_guild.roles, name=REACTION_ROLES_MAP[reaction.emoji])
-            except KeyError:
-                logger.warning(f"Role for Emoji '{reaction.emoji.name}' sent by user '{member.name}' in channel {_channel.name} not found, removing reaction")
-                await reaction.clear()
-                continue
-
-            try:
-                async for member in reaction.users():
-                    # Skip admins bc we don't want to get EVERY role all the time
-                    if member.name in REACTION_ROLE_RESTORE_IGNORED_MEMBERS:
-                        continue
-
-                    # Check if user already has the role:
-                    try:
-                       _role = discord.utils.get(_guild.roles, name=REACTION_ROLES_MAP[reaction.emoji])
-                    except KeyError:
-                        print(
-                            "Reaction roles restore: Role for Emoji '" + reaction.emoji.name + "' not found, removing reaction.")
-                        await reaction.clear()
-                        print("Reaction roles restore: Cleared reaction")
-                        continue
-                    if not _role in member.roles:
-                        logger.info(f"User '{member.name}' does not yet have the '{REACTION_ROLES_MAP[reaction.emoji]}' role, but has sent the reaction for it. Adding role now")
-                        try:
-                            await member.add_roles(_role)
-                        except discord.HTTPException:
-                            logger.error("HTTPException")
-                            pass
-
-            except discord.HTTPException:
-                logger.error("HTTPException")
 
 def main():
     logging.basicConfig(format='%(asctime)s %(levelname)s - [%(funcName)s() @ %(module)s.py:%(lineno)d] %(message)s', datefmt='%d-%m-%y %H:%M:%S', level=logging.INFO)

--- a/kanao.py
+++ b/kanao.py
@@ -33,74 +33,8 @@ bot = commands.Bot(command_prefix='k!', intents=intents, help_command=None)
 load functionality that is defined in other modules
 """
 bot.load_extension("roles")
+bot.load_extension("message_events")
 
-"""
-
-check if a message tries to role mention without using k!pingRole
-advise user if that's the case
-Extensible for further message checks
-
-"""
-
-
-@bot.event
-async def on_message(message):
-    if message.author.bot:
-        return
-    _ctx = await bot.get_context(message)
-    if _ctx.valid:
-        await bot.process_commands(message)
-        return
-    if _ctx.message.raw_role_mentions:
-        if not _ctx.author.guild_permissions.mention_everyone:
-            logger.warning(f"User {_ctx.author.name} tried to use raw role mentions without permissions in channel '{_ctx.channel.name}'")
-            await message.channel.send("Normal users need to use the k!pingRole command to mention a role!", reference=message)
-
-
-"""
-log message edits
-will not be called if the message isn't in the msg cache (anymore). 
-the msg cache, by default is 5k, which i deem enough.
-otherwise, on_raw_message_edit is recommended, or raising Client.max_messages
-
-"""
-
-
-@bot.event
-async def on_message_edit(before, after):
-    if before.author.bot:
-        return
-    _editLogChannel = bot.get_channel(MESSAGE_EDIT_LOG)
-    print(_editLogChannel)
-    await _editLogChannel.send("```EDIT EVENT:\n\n" + "User: " + before.author.name + "\n\n" +
-                        "Before: " + before.content + "\n\n" +
-                        "After: " + after.content + "```")
-
-""" 
-
-message delete event
-same things as with on_message_edit apply
-
-"""
-@bot.event
-async def on_message_delete(message):
-    _editLogChannel = bot.get_channel(MESSAGE_EDIT_LOG)
-    await _editLogChannel.send("```MSG DELETE EVENT:\n\n" + "User: " + message.author.name + "\n\n" +
-                        "Channel: " + message.channel.name + "\n"
-                        "Message: " + message.content + "```")
-
-@bot.event
-async def on_raw_bulk_message_delete(payload):
-    _modLogChannel = bot.get_channel(MOD_LOG)
-    _eventChannel = bot.get_channel(payload.channel_id)
-    try:
-        await _modLogChannel.send("```!! BULK DELETE EVENT !!" + "\n\n" + "Channel :" + _eventChannel.name + "\n\n"
-                                 "Trying to get possibly cached messages: ```")
-        for _msg in payload.cached_messages:
-            await _modLogChannel.send("```" + _msg.author.name + ":\n" + _msg.content + "\n" + "```")
-
-    except:
-        await _modLogChannel.send("Failed getting any cached messages.")
 
 @bot.command(aliases=["h", "help"])
 async def custom_help(ctx):

--- a/message_events.py
+++ b/message_events.py
@@ -1,0 +1,85 @@
+from discord.ext.commands import Bot
+import logging
+
+from reaction_roles import *
+
+logger = logging.getLogger(__name__)
+
+"""
+
+check if a message tries to role mention without using k!pingRole
+advise user if that's the case
+Extensible for further message checks
+
+"""
+
+
+def get_on_message(bot: Bot):
+    async def on_message(message):
+        if message.author.bot:
+            return
+        _ctx = await bot.get_context(message)
+        if _ctx.valid:
+            await bot.process_commands(message)
+            return
+        if _ctx.message.raw_role_mentions:
+            if not _ctx.author.guild_permissions.mention_everyone:
+                logger.warning(f"User {_ctx.author.name} tried to use raw role mentions without permissions in channel '{_ctx.channel.name}'")
+                await message.channel.send("Normal users need to use the k!pingRole command to mention a role!", reference=message)
+    return on_message
+
+
+"""
+log message edits
+will not be called if the message isn't in the msg cache (anymore). 
+the msg cache, by default is 5k, which i deem enough.
+otherwise, on_raw_message_edit is recommended, or raising Client.max_messages
+
+"""
+
+
+def get_on_message_edit(bot: Bot):
+    async def on_message_edit(before, after):
+        if before.author.bot:
+            return
+        _editLogChannel = bot.get_channel(MESSAGE_EDIT_LOG)
+        print(_editLogChannel)
+        await _editLogChannel.send("```EDIT EVENT:\n\n" + "User: " + before.author.name + "\n\n" +
+                            "Before: " + before.content + "\n\n" +
+                            "After: " + after.content + "```")
+    return on_message_edit
+
+""" 
+
+message delete event
+same things as with on_message_edit apply
+
+"""
+def get_on_message_delete(bot):
+    async def on_message_delete(message):
+        _editLogChannel = bot.get_channel(MESSAGE_EDIT_LOG)
+        await _editLogChannel.send("```MSG DELETE EVENT:\n\n" + "User: " + message.author.name + "\n\n" +
+                            "Channel: " + message.channel.name + "\n"
+                            "Message: " + message.content + "```")
+    return on_message_delete
+
+def get_on_raw_bulk_message_delete(bot):
+    async def on_raw_bulk_message_delete(payload):
+        _modLogChannel = bot.get_channel(MOD_LOG)
+        _eventChannel = bot.get_channel(payload.channel_id)
+        try:
+            await _modLogChannel.send("```!! BULK DELETE EVENT !!" + "\n\n" + "Channel :" + _eventChannel.name + "\n\n"
+                                     "Trying to get possibly cached messages: ```")
+            for _msg in payload.cached_messages:
+                await _modLogChannel.send("```" + _msg.author.name + ":\n" + _msg.content + "\n" + "```")
+
+        except:
+            await _modLogChannel.send("Failed getting any cached messages.")
+    return on_raw_bulk_message_delete
+
+def setup(bot: Bot):
+    bot.add_listener(get_on_message(bot))
+    bot.add_listener(get_on_message_edit(bot))
+    bot.add_listener(get_on_message_delete(bot))
+    bot.add_listener(get_on_raw_bulk_message_delete(bot))
+

--- a/misc.py
+++ b/misc.py
@@ -1,0 +1,68 @@
+from discord.ext.commands import Bot
+from discord.ext import commands
+from discord.utils import get
+import logging
+
+logger = logging.getLogger(__name__)
+"""
+
+method to make the user use the bot to ping roles.
+this ensures we can log pings to roles, and that people only ping roles they have themselves.
+
+"""
+@commands.command(aliases=['pr'])
+async def pingRole(ctx, arg):
+    _raw_role_ID = ctx.message.raw_role_mentions       # this returns a LIST, not an INT
+    if not _raw_role_ID:                               # will be empty if @everyone/@here or if no mention (duh)
+        logger.warning(f"User '{ctx.author.name}' tried to ping with empty _raw_role_ID (@everone/@here/no mention) in channel '{ctx.channel.name}'")
+        await ctx.send("Make sure to put @role and a spacebar behind, so it looks like a ping. \nI wont ping @ everyone or @ here.", reference=ctx.message)
+        return
+
+    _roleName = get(ctx.guild.roles, id=_raw_role_ID[0])
+    
+    if _roleName in ctx.author.roles:
+        logger.info(f"Pinging role '{_roleName}' for user '{ctx.author.name}' in channel '{ctx.channel.name}'")
+        await ctx.send('<@&' + str(_raw_role_ID[0]) + '>', reference=ctx.message)
+    else :
+        logger.warning(f"User '{ctx.author.name}' tried to ping role '{_roleName}' in channel '{ctx.channel.name}', but they don't have that role")
+        await ctx.send('You need to have the role yourself to have me ping it!')
+
+
+"""
+
+gives the mentioned users pfp
+
+"""
+
+@commands.command(aliases=['av'])
+async def avatar(ctx):
+    for _user in ctx.message.mentions:
+        logger.info(f"Showing avatar from user '{_user}' for user '{ctx.author.name}' in channel '{ctx.channel.name}'")
+        await ctx.send(_user.avatar_url)
+
+async def cat(ctx, arg='UwU'):
+    # Sauce: https://http.cat
+    _valid_http_status_codes = [
+     "100", "101", "102", "200", "201", "202", "203", "204", "206",
+     "207", "300", "301", "302", "303", "304", "305", "307", "308",
+     "400", "401", "402", "403", "404", "405", "406", "407", "408",
+     "409", "410", "411", "412", "413", "414", "415", "416", "417",
+     "418", "420", "421", "422", "424", "425", "426", "429", "431",
+     "444", "450", "451", "497", "498", "499", "500", "501", "502",
+     "503", "504", "506", "507", "508", "509", "510", "511", "521",
+     "523", "525", "599"
+    ]
+
+    if arg in _valid_http_status_codes:
+        await ctx.send(f'https://http.cat/{arg}')
+        logger.info(f"Sent http-cat with statuscode '{arg}' for user '{ctx.author.name}' in channel '{ctx.channel.name}'")
+    else:
+        logger.warning(f"Invalid status code ({arg}) from user '{ctx.author.name}' in channel '{ctx.channel.name}'")
+        await ctx.send('You must supply a valid numeric http status code!')
+        await ctx.send('https://http.cat/400')
+
+
+def setup(bot: Bot):
+    bot.add_command(pingRole)
+    bot.add_command(avatar)
+    bot.add_command(cat)

--- a/misc.py
+++ b/misc.py
@@ -40,6 +40,7 @@ async def avatar(ctx):
         logger.info(f"Showing avatar from user '{_user}' for user '{ctx.author.name}' in channel '{ctx.channel.name}'")
         await ctx.send(_user.avatar_url)
 
+@commands.command()
 async def cat(ctx, arg='UwU'):
     # Sauce: https://http.cat
     _valid_http_status_codes = [

--- a/purge.py
+++ b/purge.py
@@ -1,0 +1,30 @@
+from discord.ext import commands
+from discord.ext.commands import Bot
+import logging
+
+logger = logging.getLogger(__name__)
+
+"""
+
+allows purging of up to 100 messages. only mods and admins.
+factors in the commanding messages automatically 
+
+"""
+
+@commands.has_any_role("Moderator", "Admin")
+async def purge(ctx, arg):
+    _to_delete = int(arg) + 1
+    _delete_list = []
+    async for message in ctx.history(limit=_to_delete):
+        _delete_list.append(message)
+    logger.info(f"Purging {_to_delete} messages for user '{ctx.author.name}' in channel '{ctx.channel.name}'")
+    await ctx.channel.delete_messages(_delete_list)
+
+@purge.error
+async def purge_error(ctx, error):
+    logger.error(f"Purge Error for user '{ctx.author.name}' in channel '{ctx.channel.name}': {error}")
+    if isinstance(error, commands.MissingAnyRole):
+        await ctx.send("No perms? 🤨", delete_after=10, reference=ctx.message)
+
+def setup(bot: Bot):
+    bot.add_command(purge)

--- a/purge.py
+++ b/purge.py
@@ -11,6 +11,7 @@ factors in the commanding messages automatically
 
 """
 
+@commands.command()
 @commands.has_any_role("Moderator", "Admin")
 async def purge(ctx, arg):
     _to_delete = int(arg) + 1

--- a/roles.py
+++ b/roles.py
@@ -1,0 +1,154 @@
+import discord
+from discord.ext.commands import Bot
+from discord.ext.commands import command
+import logging
+
+from discord.raw_models import RawReactionActionEvent
+
+from reaction_roles import *
+
+logger = logging.getLogger(__name__)
+
+"""
+
+Check for missed reactions while offline
+
+"""
+def get_on_ready(bot):
+    async def on_ready():
+        logger.info(f'{command.user} has connected to Discord')
+        if SERVER_ID is not None:
+            logger.info("Checking if we missed any reaction roles while offline")
+            await restore_reaction_roles(bot)
+        else:
+            logger.warning("No SERVER_ID set, skipping reaction role restoration")
+        logger.info(f'{command.user} has finished initialising')
+        await command.change_presence(activity=discord.Game(name="k!help"))
+    return on_ready
+
+"""
+
+Reaction roles add
+
+"""
+def get_on_raw_reaction_add(bot: Bot):
+    async def on_raw_reaction_add(payload):
+        _role = await get_role(bot, payload)
+        if _role is not None:
+            try:
+                await payload.member.add_roles(_role)
+                logger.info(f"Added role '{_role.name}' to user '{payload.member.name}'")
+            except discord.HTTPException:
+                logger.error("HTTPException")
+                payload.channel.send("It appears the discord API is not available.\nPlease contact an admin if the problem persists.", delete_after=30)
+                pass
+    return on_raw_reaction_add
+
+"""
+
+Reaction roles remove
+
+"""
+def get_on_raw_reaction_remove(bot):
+    async def on_raw_reaction_remove(payload: RawReactionActionEvent):
+        _role = await get_role(bot, payload)
+
+        if _role is not None:
+            try:
+                _guild = bot.get_guild(payload.guild_id)
+                _member = _guild.get_member(payload.user_id)
+                if _member is None:
+                    logger.error(f"Could not find user '{_member.name}'")
+                    return
+
+                await _member.remove_roles(_role)
+                logger.info(f"Removed role '{_role.name}' from user '{_member.name}'")
+            except discord.HTTPException:
+                logger.error("HTTPException")
+                payload.channel.send("It appears the discord API is not available.\nPlease contact an admin if the problem persists.", delete_after=30)
+                pass
+    return on_raw_reaction_remove
+
+"""
+
+Retrieves a role for a given reaction by looking up the emoji in the REACTION_ROLES_MAP list.
+Also clears reaction-emojis that are not in the list from the message
+
+"""
+async def get_role(bot: Bot, payload):
+    if payload.message_id in REACTION_ROLE_MSG_IDS.values():
+        _guild = bot.get_guild(payload.guild_id)
+        if _guild is None:
+            logger.error("No guild/server??")
+            return
+        try:
+            return discord.utils.get(_guild.roles, name=REACTION_ROLES_MAP[payload.emoji.name])
+        except KeyError:
+            print("Reaction roles: Role for Emoji '" + payload.emoji.name + "' not found, removing reaction.")
+            _channel = bot.get_channel(payload.channel_id)
+            logger.warning(f"User '{payload.member.name}' reacted with '{payload.emoji.name}' in channel '{_channel.name}', but no role was found for that emoji. Removing reaction")
+            _msg = await _channel.fetch_message(payload.message_id)
+            for _reaction in _msg.reactions:
+                if str(_reaction.emoji) == str(payload.emoji):
+                    await _reaction.clear()
+                print("Reaction Roles: Cleared reaction")
+                return
+ 
+"""
+
+Checks if all users who reacted to the selfroles-msg have the corresponding role & gives it to them if they don't.
+Also clears all reactions that are not corresponding to a role.
+
+"""
+async def restore_reaction_roles(bot: Bot):
+    for channel_id in REACTION_ROLE_MSG_IDS.keys():
+        _channel = bot.get_channel(channel_id)
+        if _channel is None:
+            logger.error(f"Could not restore reaction roles: channel_id '{channel_id}' not found. Quitting")
+            return
+
+        try:
+            _msg = await _channel.fetch_message(REACTION_ROLE_MSG_IDS[channel_id])
+        except Exception as e:
+            logger.error(f"Could not fetch channel: {e}")
+            return
+
+        _guild = bot.get_guild(int(SERVER_ID))
+        for reaction in _msg.reactions:
+            try:
+                _role = discord.utils.get(_guild.roles, name=REACTION_ROLES_MAP[reaction.emoji])
+            except KeyError:
+                logger.warning(f"Role for Emoji '{reaction.emoji.name}' sent by user '{member.name}' in channel {_channel.name} not found, removing reaction")
+                await reaction.clear()
+                continue
+
+            try:
+                async for member in reaction.users():
+                    # Skip admins bc we don't want to get EVERY role all the time
+                    if member.name in REACTION_ROLE_RESTORE_IGNORED_MEMBERS:
+                        continue
+
+                    # Check if user already has the role:
+                    try:
+                       _role = discord.utils.get(_guild.roles, name=REACTION_ROLES_MAP[reaction.emoji])
+                    except KeyError:
+                        print(
+                            "Reaction roles restore: Role for Emoji '" + reaction.emoji.name + "' not found, removing reaction.")
+                        await reaction.clear()
+                        print("Reaction roles restore: Cleared reaction")
+                        continue
+                    if not _role in member.roles:
+                        logger.info(f"User '{member.name}' does not yet have the '{REACTION_ROLES_MAP[reaction.emoji]}' role, but has sent the reaction for it. Adding role now")
+                        try:
+                            await member.add_roles(_role)
+                        except discord.HTTPException:
+                            logger.error("HTTPException")
+                            pass
+
+            except discord.HTTPException:
+                logger.error("HTTPException")
+
+def setup(bot: Bot) -> None:
+    bot.add_listener(get_on_ready(bot))
+    bot.add_listener(get_on_raw_reaction_add(bot))
+    bot.add_listener(get_on_raw_reaction_remove(bot))

--- a/roles.py
+++ b/roles.py
@@ -1,4 +1,5 @@
 import discord
+from discord.ext import commands
 from discord.ext.commands import Bot
 from discord.ext.commands import command
 import logging
@@ -16,14 +17,14 @@ Check for missed reactions while offline
 """
 def get_on_ready(bot):
     async def on_ready():
-        logger.info(f'{command.user} has connected to Discord')
+        logger.info(f'{bot.user} has connected to Discord')
         if SERVER_ID is not None:
             logger.info("Checking if we missed any reaction roles while offline")
             await restore_reaction_roles(bot)
         else:
             logger.warning("No SERVER_ID set, skipping reaction role restoration")
-        logger.info(f'{command.user} has finished initialising')
-        await command.change_presence(activity=discord.Game(name="k!help"))
+        logger.info(f'{bot.user} has finished initialising')
+        await bot.change_presence(activity=discord.Game(name="k!help"))
     return on_ready
 
 """


### PR DESCRIPTION
This looks like a lot of stuff, but it's mostly the same as before, just moved around.

This PR tries to separate the functionality that was aggregated in `kanao.py` into different files, that all cover only one concern (except for `misc.py`). This makes navigating in the code much easier.

To achive this, the [extension pattern](https://discordpy.readthedocs.io/en/stable/ext/commands/extensions.html) is used. It also makes heavy use of closures, s.th. functions that rely on the bot (i.e. have some call to `bot.some_func()`) can be defined before the bot is defined.

This could also make testing easier, but that's a topic for another day. :shrug: 