### PR TITLE
remove the custom help in favour of the default help

### DIFF
--- a/kanao.py
+++ b/kanao.py
@@ -25,7 +25,14 @@ get intents from discord, privileged intents are needed
 
 intents = discord.Intents.default()
 intents.members = True
-bot = commands.Bot(command_prefix='k!', intents=intents, help_command=None)
+bot = commands.Bot(
+        command_prefix='k!',
+        intents=intents,
+        description="Hello! I'm Kanao, your friendly mod bot.",
+        help_command=commands.DefaultHelpCommand(
+            no_category="Other",
+        ),
+)
 
 """
 
@@ -35,16 +42,6 @@ bot.load_extension("roles")
 bot.load_extension("message_events")
 bot.load_extension("purge")
 bot.load_extension("misc")
-
-
-@bot.command(aliases=["h", "help"])
-async def custom_help(ctx):
-    logger.info(f"User '{ctx.author.name}' used the help command in channel '{ctx.channel.name}'")
-    await ctx.send('```' + 'k!av @mention to get someones pfp\n' +
-                   'k!purge n to delete the last n+1 messages (mod+ only, <= 100 max) \n' +
-                    'k!pingRole @role to ping that role (make sure to put a spacebar after the role, ' +
-                    'so it looks like a ping!)\n' + 'k!cat <http code> sends a http cat' +
-                    '```', reference=ctx.message)
 
 
 def main():

--- a/message_events.py
+++ b/message_events.py
@@ -8,7 +8,9 @@ from reaction_roles import *
 logger = logging.getLogger(__name__)
 
 
-class MessageEvents(Cog):
+class MessageEvents(Cog,
+    description="Events, that relate to messages.",
+):
 
     def __init__(self, bot: Bot):
         self.bot = bot

--- a/misc.py
+++ b/misc.py
@@ -8,18 +8,29 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-class Misc(Cog):
+class Misc(Cog,
+        description="Some commands, that do are not part of a specific category.",
+):
 
 
     def __init__(self, bot: Bot):
         self.bot = bot
+
+
     """
 
     method to make the user use the bot to ping roles.
     this ensures we can log pings to roles, and that people only ping roles they have themselves.
 
     """
-    @commands.command(aliases=['pr', 'pingRole'])
+    @commands.command(
+            name="pingRole",
+            aliases=['pr'],
+            description="Ping the role that is mentioned in the message.",
+            help="Ping the mentioned role. Make sure to put a spacebar after the role, so it looks like a ping!",
+            brief="Ping a role.",
+            usage="[@role] <your text>",
+    )
     async def ping_role(self, ctx):
         _raw_role_ID = ctx.message.raw_role_mentions       # this returns a LIST, not an INT
         if not _raw_role_ID:                               # will be empty if @everyone/@here or if no mention (duh)
@@ -45,14 +56,22 @@ class Misc(Cog):
     gives the mentioned users pfp
 
     """
-    @commands.command(aliases=['av'])
+    @commands.command(
+            aliases=['av'],
+            description="Gathers the link to someones profile picture to post it in the chat.",
+            # help not needed here
+            brief="See someones profile picture.",
+            usage="[@mention]",
+    )
     async def avatar(self, ctx):
         for _user in ctx.message.mentions:
             logger.info(f"Showing avatar from user '{_user}' for user '{ctx.author.name}' in channel '{ctx.channel.name}'")
             await ctx.send(_user.avatar_url, reference=ctx.message)
 
 
-    @commands.command()
+    @commands.command(
+            help="Send an HTTP cat.",
+    )
     async def cat(self, ctx, arg='UwU'):
         # Sauce: https://http.cat
         _valid_http_status_codes = [

--- a/misc.py
+++ b/misc.py
@@ -100,7 +100,11 @@ class Misc(Cog,
     (yes i was bored)
 
     """
-    @commands.command(aliases=["gun", "gat"])
+    @commands.command(
+            name="gun",
+            aliases=["kanao_gun", "gat"],
+            help="Gun.",
+    )
     @commands.has_any_role("Moderator", "Admin")
     async def kanao_gun(self, ctx):
         if ctx.message.reference:

--- a/purge.py
+++ b/purge.py
@@ -6,7 +6,9 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-class Purge(Cog):
+class Purge(Cog,
+        description="Provide the purge command to delete messages.",
+):
 
     def __init__(self, bot: Bot):
         self.bot = bot
@@ -17,7 +19,11 @@ class Purge(Cog):
     factors in the commanding messages automatically 
 
     """
-    @commands.command()
+    @commands.command(
+        help="Cleanup messages.",
+        description="Looks into the history and deletes the number of messages specified.",
+        usage="[number of messages]",
+    )
     @commands.has_any_role("Moderator", "Admin")
     async def purge(self, ctx, arg):
         _to_delete = int(arg) + 1


### PR DESCRIPTION
The custom help was hard coded. This PR removes the hardcoded PR and introduces the default `discord.py` help command.

It's features are
- automatically collecting available commands
- only showing the commands, that the requesting user can use (due to their permissions)
- displays the help that is defined _on the command_, instead of a text that is defined on a central place
- display advanced help for a specific command by calling `k!help someCommand`
and more, but those are the points that I wanted to have so far.

So what this PR actually does is to remove the `custom_help` and instead placing the help on the commands.