### PR TITLE
fixed error in roles.py when User is not Member

### DIFF
--- a/roles.py
+++ b/roles.py
@@ -107,6 +107,12 @@ async def restore_reaction_roles(bot):
 
             try:
                 async for member in reaction.users():
+                    # Check if the User is a Member:
+                    if _guild.get_member(member.id) is None:
+                        logger.info(f"User '{member.name}' is not a Member. Removing his reaction")
+                        await reaction.remove(member)
+                        continue
+
                     # Skip admins bc we don't want to get EVERY role all the time
                     if member.name in REACTION_ROLE_RESTORE_IGNORED_MEMBERS:
                         continue

--- a/roles.py
+++ b/roles.py
@@ -110,7 +110,12 @@ async def restore_reaction_roles(bot):
                     # Check if the User is a Member:
                     if _guild.get_member(member.id) is None:
                         logger.info(f"User '{member.name}' is not a Member. Removing his reaction")
-                        await reaction.remove(member)
+                        try:
+                            await reaction.remove(member)
+                        except discord.HTTPException:
+                            logger.error("HTTPException")
+                        except Exception as e:
+                            logger.error(e)
                         continue
 
                     # Skip admins bc we don't want to get EVERY role all the time


### PR DESCRIPTION
Added a check to determine if all reaction-Users are actually Server Members. It also removes the reaction if they are not, which should keep it clean for the future.